### PR TITLE
Add per-post metadata for all blog pages (OG/Twitter) with canonical URLs

### DIFF
--- a/app/blogs/(blogs)/building-a-cli-agent/page.mdx
+++ b/app/blogs/(blogs)/building-a-cli-agent/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "Building a CLI Agent",
+  description:
+    "My experience building a terminal-based AI agent and demystifying the hype around agents.",
+  openGraph: {
+    title: "Building a CLI Agent",
+    description:
+      "My experience building a terminal-based AI agent and demystifying the hype around agents.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/building-a-cli-agent",
+    images: [
+      "https://lakshyaag.com/blogs/building-a-cli-agent/wrecking-its-environment.jpeg",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Building a CLI Agent",
+    description:
+      "My experience building a terminal-based AI agent and demystifying the hype around agents.",
+    images: [
+      "https://lakshyaag.com/blogs/building-a-cli-agent/wrecking-its-environment.jpeg",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/building-a-cli-agent" },
+};
+
 _TL;DR: I built a CLI agent in Go (never touched Go before) using `claude-4-sonnet` and `gemini-2.5-pro` in Cursor. Having messed around with agents since the ReAct papers dropped in early 2024, the core loop is simple - it's just an LLM with tools in a loop. The hype makes it sound way more complex than it actually is._
 
 Here's a quick demo of my CLI agent in action:

--- a/app/blogs/(blogs)/building-a-transformer/page.mdx
+++ b/app/blogs/(blogs)/building-a-transformer/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "Building a Transformer",
+  description:
+    "A detailed breakdown of the Transformer architecture, focusing on encoder-decoder blocks and self-attention.",
+  openGraph: {
+    title: "Building a Transformer",
+    description:
+      "A detailed breakdown of the Transformer architecture, focusing on encoder-decoder blocks and self-attention.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/building-a-transformer",
+    images: [
+      "https://lakshyaag.com/blogs/building-a-transformer/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Building a Transformer",
+    description:
+      "A detailed breakdown of the Transformer architecture, focusing on encoder-decoder blocks and self-attention.",
+    images: [
+      "https://lakshyaag.com/blogs/building-a-transformer/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/building-a-transformer" },
+};
+
 <Cover
   src="/blogs/building-a-transformer/cover.png"
   alt="Building a Transformer"

--- a/app/blogs/(blogs)/building-lstms-from-scratch/page.mdx
+++ b/app/blogs/(blogs)/building-lstms-from-scratch/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "Building LSTMs from Scratch",
+  description:
+    "A step-by-step implementation guide for building multi-layer LSTMs from scratch in Python.",
+  openGraph: {
+    title: "Building LSTMs from Scratch",
+    description:
+      "A step-by-step implementation guide for building multi-layer LSTMs from scratch in Python.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/building-lstms-from-scratch",
+    images: [
+      "https://lakshyaag.com/blogs/building-lstms-from-scratch/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Building LSTMs from Scratch",
+    description:
+      "A step-by-step implementation guide for building multi-layer LSTMs from scratch in Python.",
+    images: [
+      "https://lakshyaag.com/blogs/building-lstms-from-scratch/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/building-lstms-from-scratch" },
+};
+
 <Cover
   src="/blogs/building-lstms-from-scratch/cover.png"
   alt="Building LSTMs from Scratch"

--- a/app/blogs/(blogs)/epl-season-14/page.mdx
+++ b/app/blogs/(blogs)/epl-season-14/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "EPL Season 14 Group D",
+  description:
+    "An analysis of ESL Pro League Season 14 Group D performance metrics and player statistics.",
+  openGraph: {
+    title: "EPL Season 14 Group D",
+    description:
+      "An analysis of ESL Pro League Season 14 Group D performance metrics and player statistics.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/epl-season-14",
+    images: [
+      "https://lakshyaag.com/blogs/epl-season-14/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "EPL Season 14 Group D",
+    description:
+      "An analysis of ESL Pro League Season 14 Group D performance metrics and player statistics.",
+    images: [
+      "https://lakshyaag.com/blogs/epl-season-14/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/epl-season-14" },
+};
+
 <Cover
   src="/blogs/epl-season-14/cover.png"
   alt="EPL Season 14 Group D"

--- a/app/blogs/(blogs)/fine-tune-gpt2-classification/page.mdx
+++ b/app/blogs/(blogs)/fine-tune-gpt2-classification/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "Fine-tuning GPT-2 for Classification",
+  description:
+    "A tutorial on fine-tuning GPT-2 for classification tasks using the Hugging Face Transformers library.",
+  openGraph: {
+    title: "Fine-tuning GPT-2 for Classification",
+    description:
+      "A tutorial on fine-tuning GPT-2 for classification tasks using the Hugging Face Transformers library.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/fine-tune-gpt2-classification",
+    images: [
+      "https://lakshyaag.com/blogs/fine-tune-gpt2-classification/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Fine-tuning GPT-2 for Classification",
+    description:
+      "A tutorial on fine-tuning GPT-2 for classification tasks using the Hugging Face Transformers library.",
+    images: [
+      "https://lakshyaag.com/blogs/fine-tune-gpt2-classification/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/fine-tune-gpt2-classification" },
+};
+
 <Cover
   src="/blogs/fine-tune-gpt2-classification/cover.png"
   alt="Fine-tuning GPT-2 for Classification"

--- a/app/blogs/(blogs)/gpt-4-vision-example/page.mdx
+++ b/app/blogs/(blogs)/gpt-4-vision-example/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "GPT-4 Vision Example",
+  description:
+    "A guide to using GPT-4 Vision API for generating advertising copy from product images.",
+  openGraph: {
+    title: "GPT-4 Vision Example",
+    description:
+      "A guide to using GPT-4 Vision API for generating advertising copy from product images.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/gpt-4-vision-example",
+    images: [
+      "https://lakshyaag.com/blogs/gpt-4-vision-example/cover.webp",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "GPT-4 Vision Example",
+    description:
+      "A guide to using GPT-4 Vision API for generating advertising copy from product images.",
+    images: [
+      "https://lakshyaag.com/blogs/gpt-4-vision-example/cover.webp",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/gpt-4-vision-example" },
+};
+
 <Cover
   src="/blogs/gpt-4-vision-example/cover.webp"
   alt="GPT-4 Vision Example"

--- a/app/blogs/(blogs)/imdb-rating-prediction/page.mdx
+++ b/app/blogs/(blogs)/imdb-rating-prediction/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "IMDb Rating Prediction",
+  description:
+    "A regression analysis project predicting IMDb movie ratings and identifying key influential features.",
+  openGraph: {
+    title: "IMDb Rating Prediction",
+    description:
+      "A regression analysis project predicting IMDb movie ratings and identifying key influential features.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/imdb-rating-prediction",
+    images: [
+      "https://lakshyaag.com/blogs/imdb-rating-prediction/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "IMDb Rating Prediction",
+    description:
+      "A regression analysis project predicting IMDb movie ratings and identifying key influential features.",
+    images: [
+      "https://lakshyaag.com/blogs/imdb-rating-prediction/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/imdb-rating-prediction" },
+};
+
 <Cover
   src="/blogs/imdb-rating-prediction/cover.png"
   alt="IMDb Rating Prediction"

--- a/app/blogs/(blogs)/langchain-primer/page.mdx
+++ b/app/blogs/(blogs)/langchain-primer/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "LangChain Primer",
+  description:
+    "An introduction to LangChain framework for AI applications, including RAG implementation and monitoring.",
+  openGraph: {
+    title: "LangChain Primer",
+    description:
+      "An introduction to LangChain framework for AI applications, including RAG implementation and monitoring.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/langchain-primer",
+    images: [
+      "https://lakshyaag.com/blogs/langchain-primer/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "LangChain Primer",
+    description:
+      "An introduction to LangChain framework for AI applications, including RAG implementation and monitoring.",
+    images: [
+      "https://lakshyaag.com/blogs/langchain-primer/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/langchain-primer" },
+};
+
 <Cover
   src="/blogs/langchain-primer/cover.png"
   alt="LangChain Primer"

--- a/app/blogs/(blogs)/llm-evals/page.mdx
+++ b/app/blogs/(blogs)/llm-evals/page.mdx
@@ -1,3 +1,31 @@
+export const metadata = {
+  title: "LLM Evals",
+  description:
+    "A tutorial on evaluating LLM performance using LangSmith for 10-K filing retrieval tasks.",
+  openGraph: {
+    title: "LLM Evals",
+    description:
+      "A tutorial on evaluating LLM performance using LangSmith for 10-K filing retrieval tasks.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/llm-evals",
+    images: [
+      "https://lakshyaag.com/blogs/llm-evals/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "LLM Evals",
+    description:
+      "A tutorial on evaluating LLM performance using LangSmith for 10-K filing retrieval tasks.",
+    images: [
+      "https://lakshyaag.com/blogs/llm-evals/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/llm-evals" },
+};
 
 <Cover
   src="/blogs/llm-evals/cover.png"

--- a/app/blogs/(blogs)/new-builds-2024/page.mdx
+++ b/app/blogs/(blogs)/new-builds-2024/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "New Builds 2024",
+  description:
+    "A recap of building a generative choose-your-own-adventure game in 24 hours at New Builds 2024 hackathon",
+  openGraph: {
+    title: "New Builds 2024",
+    description:
+      "A recap of building a generative choose-your-own-adventure game in 24 hours at New Builds 2024 hackathon",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/new-builds-2024",
+    images: [
+      "https://lakshyaag.com/blogs/new-builds-2024/cover.jpeg",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "New Builds 2024",
+    description:
+      "A recap of building a generative choose-your-own-adventure game in 24 hours at New Builds 2024 hackathon",
+    images: [
+      "https://lakshyaag.com/blogs/new-builds-2024/cover.jpeg",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/new-builds-2024" },
+};
+
 <Cover
   src="/blogs/new-builds-2024/cover.jpeg"
   alt="New Builds 2024"

--- a/app/blogs/(blogs)/rl-environments/page.mdx
+++ b/app/blogs/(blogs)/rl-environments/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "Building RL environments for open-source AGI",
+  description:
+    "Weekend notes on porting environments, running evaluations, and serving LMs on a cloud-hosted GPU.",
+  openGraph: {
+    title: "Building RL environments for open-source AGI",
+    description:
+      "Weekend notes on porting environments, running evaluations, and serving LMs on a cloud-hosted GPU.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/rl-environments",
+    images: [
+      "https://lakshyaag.com/blogs/rl-environments/AE_loop.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Building RL environments for open-source AGI",
+    description:
+      "Weekend notes on porting environments, running evaluations, and serving LMs on a cloud-hosted GPU.",
+    images: [
+      "https://lakshyaag.com/blogs/rl-environments/AE_loop.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/rl-environments" },
+};
+
 # Building RL environments for open-source AGI
 
 <div className="flex justify-center">

--- a/app/blogs/(blogs)/understanding-diffusion/page.mdx
+++ b/app/blogs/(blogs)/understanding-diffusion/page.mdx
@@ -1,3 +1,32 @@
+export const metadata = {
+  title: "Understanding the diffusion process",
+  description:
+    "An exploration of the DDPM paper by Ho et al., covering core concepts of diffusion models for image generation.",
+  openGraph: {
+    title: "Understanding the diffusion process",
+    description:
+      "An exploration of the DDPM paper by Ho et al., covering core concepts of diffusion models for image generation.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/understanding-diffusion",
+    images: [
+      "https://lakshyaag.com/blogs/understanding-diffusion/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Understanding the diffusion process",
+    description:
+      "An exploration of the DDPM paper by Ho et al., covering core concepts of diffusion models for image generation.",
+    images: [
+      "https://lakshyaag.com/blogs/understanding-diffusion/cover.png",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/understanding-diffusion" },
+};
+
 <Cover
   src="/blogs/understanding-diffusion/cover.png"
   alt="Understanding the diffusion process"

--- a/app/blogs/(blogs)/vibe-coding-a-digtal-wardrobe/page.mdx
+++ b/app/blogs/(blogs)/vibe-coding-a-digtal-wardrobe/page.mdx
@@ -1,3 +1,29 @@
+export const metadata = {
+  title: "Vibe-coding a digital wardrobe",
+  description: "My thoughts on vibe-coding as of May 2025.",
+  openGraph: {
+    title: "Vibe-coding a digital wardrobe",
+    description: "My thoughts on vibe-coding as of May 2025.",
+    type: "article",
+    url: "https://lakshyaag.com/blogs/vibe-coding-a-digtal-wardrobe",
+    images: [
+      "https://lakshyaag.com/blogs/vibe-coding-a-digtal-wardrobe/digital-wardrobe-demo.mp4",
+      "https://lakshyaag.com/og.png",
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Vibe-coding a digital wardrobe",
+    description: "My thoughts on vibe-coding as of May 2025.",
+    images: [
+      "https://lakshyaag.com/blogs/vibe-coding-a-digtal-wardrobe/digital-wardrobe-demo.mp4",
+      "https://lakshyaag.com/og.png",
+    ],
+    creator: "@lakshyaag",
+  },
+  alternates: { canonical: "/blogs/vibe-coding-a-digtal-wardrobe" },
+};
+
 # Vibe-coding a digital wardrobe
 
 _This project was done in late April - early May 2025. I started writing this blog post after I was done, but never got around to finishing it. I'm posting it in late July 2025 to clear my backlog._


### PR DESCRIPTION
## Summary
Implemented unique metadata per blog post so shared links show the correct title, description, and preview image.
No UI or content changes; build and lint pass.

## Motivation
Previously, all pages inherited the same site-wide title/description, causing incorrect previews on social shares. This PR ensures each blog post reflects its actual content when shared.

## Changes
Added export const metadata to each blog page.mdx:
title and description specific to the post
openGraph and twitter objects (type: article)
canonical URL via alternates.canonical
OG/Twitter images prefer the post’s cover where available, with fallback to /og.png
No changes to layout/components.