### PR TITLE
Fix blog post og image uniqueness

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,13 +21,6 @@ export const metadata: Metadata = {
 	openGraph: {
 		title: "Lakshya Agarwal",
 		description: "Lakshya Agarwal's personal corner on the Internet!",
-		images: [
-			{
-				url: "/og.png",
-				width: 800,
-				height: 400,
-			},
-		],
 		url: "https://lakshyaag.com",
 		locale: "en_US",
 		type: "website",
@@ -37,7 +30,6 @@ export const metadata: Metadata = {
 		card: "summary_large_image",
 		title: "Lakshya Agarwal",
 		description: "Lakshya Agarwal's personal corner on the Internet!",
-		images: ["/og.png"],
 		creator: "@lakshyaag",
 	},
 };


### PR DESCRIPTION
Remove global OG/Twitter images to allow individual blog posts to display their unique OG images.

---
<a href="https://cursor.com/background-agent?bcId=bc-48ada3d2-8d85-4042-85d5-378cbd190555">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48ada3d2-8d85-4042-85d5-378cbd190555">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

